### PR TITLE
fix: auto-detection of file type

### DIFF
--- a/tools/arc/lint/buildifier.sh
+++ b/tools/arc/lint/buildifier.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-buildifier < $1
+buildifier --path $1 < $1


### PR DESCRIPTION
I noticed that using `arc lint` was not reporting some changes that were indeed caused when running `buildifier $1` directly.
I read in the [`buildifier` readme](https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md#usage) that there is an automatic file detection based on the filename, which is not possible when using the input is stdin (or a pipe in this case).

I was tempted to add some `case` logic to detect the correct type from the `buildifier.sh` wrapper and pass the proper `--type`, but then I noticed about this `--path` flag.